### PR TITLE
Use max zoom from tile usage policy

### DIFF
--- a/src/org/openstreetmap/fma/jtiledownloader/datatypes/MapnikTileProvider.java
+++ b/src/org/openstreetmap/fma/jtiledownloader/datatypes/MapnikTileProvider.java
@@ -51,6 +51,6 @@ public class MapnikTileProvider
     @Override
     public int getMaxZoom()
     {
-        return 19;
+        return 12;
     }
 }


### PR DESCRIPTION
The [tile usage policy](https://operations.osmfoundation.org/policies/tiles/) restricts bulk downloading tiles to zoom 12.